### PR TITLE
Remove unused turtle import

### DIFF
--- a/minesweepervariants/impl/impl_obj.py
+++ b/minesweepervariants/impl/impl_obj.py
@@ -8,7 +8,6 @@ import os
 import sys
 import importlib.util
 from pathlib import Path
-from turtle import st
 from typing import Optional
 
 from minesweepervariants.utils.tool import get_logger


### PR DESCRIPTION
Remove unused turtle import to avoid potential dependency issues caused by tk,

as in the screenshot below:

<img width="1518" height="526" alt="08EQ(FWJM192 ZEJ_UCE{AO" src="https://github.com/user-attachments/assets/b2835470-9484-449f-9f49-9132da032151" />
